### PR TITLE
Add paragraph to explain that Mobile Services already show up in Metrics

### DIFF
--- a/making-mobile-services-discoverable-by-metrics.adoc
+++ b/making-mobile-services-discoverable-by-metrics.adoc
@@ -1,6 +1,9 @@
-= Making mobile services auto-discoverable by the metrics service
+= Making Services auto-discoverable by the Metrics Service
 
-In order to make a service auto-discoverable by the metrics service:
+Mobile Services that expose a metrics endpoint will already be auto-discovered by the Metrics Service.
+No additional steps are needed for Prometheus to poll for metrics from Mobile Services.
+
+However, if you would like the Metrics Services to also gather metrics from your own Service, you will need the following:
 
 * Service has to have one of `org.aerogear.metrics/plain_endpoint` or
 `org.aerogear.metrics/ssl_endpoint` annotations.


### PR DESCRIPTION
This should help remove any ambiguity about if developers *have* to do something (they don't) and when they might want to (with their own service)